### PR TITLE
Up initial poll call to 10 seconds.

### DIFF
--- a/lib/remix.ex
+++ b/lib/remix.ex
@@ -23,7 +23,7 @@ defmodule Remix do
     defmodule State, do: defstruct last_mtime: nil
 
     def start_link do
-      Process.send_after(__MODULE__, :poll_and_reload, 1000)
+      Process.send_after(__MODULE__, :poll_and_reload, 10000)
       GenServer.start_link(__MODULE__, %State{}, name: Remix.Worker)
     end
 


### PR DESCRIPTION
This has a couple of effects:
1. Compile failures do not happen so quickly that the supervisor gives
   up and the app stops.
2. The first poll is delayed, so any changes will have a lag time.
3. Remix will continue trying to re-compile every 10 seconds
   indefinitly.
