### PR TITLE
Add folder watch customization option

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Remix
 
-Recompiles mix project on any lib file change/addition.
+Recompiles mix project on any file change/addition (defaults to only watching `lib`).
 
 Intended for development use only.
 
@@ -27,18 +27,28 @@ defp applications(_all), do: [:logger]
 
 ```
 
-with escript compilation (in config.exs) and
-silent mode (won't output to iex each time it compiles):
+## Config
+  * `dirs` (default `"lib"`): A list of directories to search, or binary of a single directory
+  * `escript` (default `false`): includes escript compilation
+  * `silent` (default `false`): suppress output to iex when compiling
+
+Watches all files in project, with escript compilation and silent mode:
 ```elixir
 config :remix,
+  dirs: "./",
   escript: true,
   silent: true
 ```
-If these vars are not set, it will default to verbose (silent: false) and no escript compilation (escript: false).
+
+Watches the `lib` and `foo` directories
+```elixir
+config :remix,
+  dirs: ["lib", "foo"]
+```
 
 ## Usage
 
-Save or create a new file in the lib directory. Thats it!
+Save or create a new file in the lib (or other specified) directory. Thats it!
 
 ## About
 

--- a/lib/remix.ex
+++ b/lib/remix.ex
@@ -54,7 +54,11 @@ defmodule Remix do
       {:noreply, state}
     end
 
-    def get_current_mtime, do: get_current_mtime("lib")
+    def get_current_mtime, do: get_current_mtime(Application.get_all_env(:remix)[:dirs] || "lib")
+
+    def get_current_mtime(dirs) when is_list(dirs) do
+      get_current_mtime([], Enum.map(dirs, &get_current_mtime/1))
+    end
 
     def get_current_mtime(dir) do
       case File.ls(dir) do
@@ -63,8 +67,11 @@ defmodule Remix do
       end
     end
 
+    def get_current_mtime(dirs, mtimes, cwd \\ nil)
+
     def get_current_mtime([], mtimes, _cwd) do
       mtimes
+      |> List.flatten
       |> Enum.sort
       |> Enum.reverse
       |> List.first

--- a/lib/remix.ex
+++ b/lib/remix.ex
@@ -31,7 +31,6 @@ defmodule Remix do
       current_mtime = get_current_mtime
 
       if state.last_mtime != current_mtime do
-        state = %State{last_mtime: current_mtime}
         comp_elixir = fn -> Mix.Tasks.Compile.Elixir.run(["--ignore-module-conflict"]) end
         comp_escript = fn -> Mix.Tasks.Escript.Build.run([]) end
 
@@ -51,7 +50,7 @@ defmodule Remix do
       end
 
       Process.send_after(__MODULE__, :poll_and_reload, 1000)
-      {:noreply, state}
+      {:noreply, %State{last_mtime: current_mtime}}
     end
 
     def get_current_mtime, do: get_current_mtime(Application.get_all_env(:remix)[:dirs] || "lib")


### PR DESCRIPTION
The app I'm working on doesn't keep everything in lib, so I needed remix to watch all of the folders. Now users can specify whether they want to watch any single folder (like `./`), or a list of folders (like `["lib", "web"]`). It will default to `lib` to match current behavior.
