### PR TITLE
Remove compilation warning about unsafe variable

### DIFF
--- a/lib/remix.ex
+++ b/lib/remix.ex
@@ -30,8 +30,7 @@ defmodule Remix do
     def handle_info(:poll_and_reload, state) do
       current_mtime = get_current_mtime
 
-      if state.last_mtime != current_mtime do
-        state = %State{last_mtime: current_mtime}
+      state = if state.last_mtime != current_mtime do
         comp_elixir = fn -> Mix.Tasks.Compile.Elixir.run(["--ignore-module-conflict"]) end
         comp_escript = fn -> Mix.Tasks.Escript.Build.run([]) end
 
@@ -48,6 +47,9 @@ defmodule Remix do
               comp_escript.()
             end
         end
+        %State{last_mtime: current_mtime}
+      else
+        state
       end
 
       Process.send_after(__MODULE__, :poll_and_reload, 1000)


### PR DESCRIPTION
Removes compilation warning when using Elixir 1.3:

```
~/remix $ mix test
Compiling 1 file (.ex)
warning: the variable "state" is unsafe as it has been set inside a case/cond/receive/if/&&/||. Please explicitly return the variable value instead. For example:

    case int do
      1 -> atom = :one
      2 -> atom = :two
    end

should be written as

    atom =
      case int do
        1 -> :one
        2 -> :two
      end

Unsafe variable found at:
  lib/remix.ex:54

Generated remix app
.

Finished in 0.01 seconds
1 test, 0 failures

Randomized with seed 887889
```