### PR TITLE
Allows multiple paths to be monitored.

### DIFF
--- a/lib/remix.ex
+++ b/lib/remix.ex
@@ -20,43 +20,47 @@ defmodule Remix do
   defmodule Worker do
     use GenServer
 
-    defmodule State, do: defstruct last_mtime: nil
-
     def start_link do
       Process.send_after(__MODULE__, :poll_and_reload, 10000)
-      GenServer.start_link(__MODULE__, %State{}, name: Remix.Worker)
+      GenServer.start_link(__MODULE__, %{}, name: Remix.Worker)
     end
 
     def handle_info(:poll_and_reload, state) do
-      current_mtime = get_current_mtime
+      paths = Application.get_all_env(:remix)[:paths]
 
-      state = if state.last_mtime != current_mtime do
-        comp_elixir = fn -> Mix.Tasks.Compile.Elixir.run(["--ignore-module-conflict"]) end
-        comp_escript = fn -> Mix.Tasks.Escript.Build.run([]) end
-
-        case Application.get_all_env(:remix)[:silent] do
-          true ->
-            ExUnit.CaptureIO.capture_io(comp_elixir)
-            if Application.get_all_env(:remix)[:escript] == true do
-              ExUnit.CaptureIO.capture_io(comp_escript)
-            end
-
-          _ ->
-            comp_elixir.()
-            if Application.get_all_env(:remix)[:escript] == true do
-              comp_escript.()
-            end
+      new_state = Map.new paths, fn (path) ->
+        current_mtime = get_current_mtime path
+        last_mtime = case Map.fetch(state, path) do
+          {:ok, val} -> val
+          :error -> nil
         end
-        %State{last_mtime: current_mtime}
-      else
-        state
+        handle_path path, current_mtime, last_mtime
       end
 
       Process.send_after(__MODULE__, :poll_and_reload, 1000)
-      {:noreply, state}
+      {:noreply, new_state}
     end
 
-    def get_current_mtime, do: get_current_mtime("lib")
+    def handle_path(path, current_mtime, current_mtime), do: {path, current_mtime}
+    def handle_path(path, current_mtime, _) do
+      comp_elixir = fn -> Mix.Tasks.Compile.Elixir.run(["--ignore-module-conflict"]) end
+      comp_escript = fn -> Mix.Tasks.Escript.Build.run([]) end
+
+      case Application.get_all_env(:remix)[:silent] do
+        true ->
+          ExUnit.CaptureIO.capture_io(comp_elixir)
+          if Application.get_all_env(:remix)[:escript] == true do
+            ExUnit.CaptureIO.capture_io(comp_escript)
+          end
+
+        _ ->
+          comp_elixir.()
+          if Application.get_all_env(:remix)[:escript] == true do
+            comp_escript.()
+          end
+      end
+      {path, current_mtime}
+    end
 
     def get_current_mtime(dir) do
       case File.ls(dir) do
@@ -67,9 +71,9 @@ defmodule Remix do
 
     def get_current_mtime([], mtimes, _cwd) do
       mtimes
-      |> Enum.sort
-      |> Enum.reverse
-      |> List.first
+        |> Enum.sort
+        |> Enum.reverse
+        |> List.first
     end
 
     def get_current_mtime([h | tail], mtimes, cwd) do
@@ -77,7 +81,7 @@ defmodule Remix do
         true  -> get_current_mtime("#{cwd}/#{h}")
         false -> File.stat!("#{cwd}/#{h}").mtime
       end
-      get_current_mtime(tail, [mtime | mtimes], cwd)
+      get_current_mtime tail, [mtime | mtimes], cwd
     end
   end
 end


### PR DESCRIPTION
This PR allows multiple paths to be monitored. It requires the user to pass a list of paths like so:

```
config :remix,
  escript: false,
  silent: false,
  paths: ["lib", "priv", "web"]
```
