### PR TITLE
Fixes #15

### DIFF
--- a/lib/remix.ex
+++ b/lib/remix.ex
@@ -27,6 +27,7 @@ defmodule Remix do
 
     def handle_info(:poll_and_reload, state) do
       paths = Application.get_all_env(:remix)[:paths]
+      paths = if is_nil(paths), do: ["lib"], else: paths
 
       new_state = Map.new paths, fn (path) ->
         current_mtime = get_current_mtime path


### PR DESCRIPTION
Fixes #15

This fixes a bug where

```
16:24:12.324 [error] GenServer Remix.Worker terminating
** (Protocol.UndefinedError) protocol Enumerable not implemented for nil
    (elixir) lib/enum.ex:1: Enumerable.impl_for!/1
    (elixir) lib/enum.ex:116: Enumerable.reduce/3
    (elixir) lib/enum.ex:1636: Enum.reduce/3
    (elixir) lib/enum.ex:2346: Enum.to_list/1
    (elixir) lib/map.ex:104: Map.new/2
    (remix) lib/remix.ex:31: Remix.Worker.handle_info/2
    (stdlib) gen_server.erl:601: :gen_server.try_dispatch/4
    (stdlib) gen_server.erl:667: :gen_server.handle_msg/5
Last message: :poll_and_reload
State: %{}
```

due to there not being a paths environment variable.