### PR TITLE
Format

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["mix.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/mix.exs
+++ b/mix.exs
@@ -2,17 +2,18 @@ defmodule Remix.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :remix,
-     version: "0.0.2",
-     elixir: "~> 1.0",
-     package: package,
-     description: description,
-     deps: deps]
+    [
+      app: :remix,
+      version: "0.0.2",
+      elixir: "~> 1.0",
+      package: package,
+      description: description,
+      deps: deps
+    ]
   end
 
   def application do
-    [applications: [:logger],
-     mod: {Remix, []}]
+    [applications: [:logger], mod: {Remix, []}]
   end
 
   defp deps, do: []

--- a/mix.exs
+++ b/mix.exs
@@ -6,9 +6,9 @@ defmodule Remix.Mixfile do
       app: :remix,
       version: "0.0.2",
       elixir: "~> 1.0",
-      package: package,
-      description: description,
-      deps: deps
+      package: package(),
+      description: description(),
+      deps: deps()
     ]
   end
 


### PR DESCRIPTION
I ran `mix format` and added some parens in mix.exs to silence warnings:

```
warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:9

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:10

warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  mix.exs:11
```